### PR TITLE
IsTerminal should not go to NN

### DIFF
--- a/src/mcts/search.cc
+++ b/src/mcts/search.cc
@@ -815,7 +815,7 @@ void SearchWorker::GatherMinibatch() {
       ExtendNode(node);
 
       // Only send non-terminal nodes to a neural network.
-      if (!node->IsCertain()) {
+      if (!node->IsCertain() && !node->IsTerminal()) {
         picked_node.nn_queried = true;
         picked_node.is_cache_hit = AddNodeToComputation(node, true);
       }


### PR DESCRIPTION
With this change, the mate in 1 is found for this position.

```
update:
position fen 6kr/5ppp/8/8/6Q1/8/5PPP/6K1 w k - 0 1
go nodes 100
info depth 1 seldepth 2 time 103 nodes 66 score cp 12800 hashfull 63 nps 640 tbhits 0 pv g4c8
info depth 1 seldepth 2 time 213 nodes 107 score cp 12800 hashfull 63 nps 502 tbhits 0 pv g4c8
info string g4g7  (868 ) N:       0 (+ 0) (P:  0.59%) (Q:  0.05473) (U: 0.18141) (Q+U:  0.23614) (V:  -.----)  C:00000000
info string g4g6  (865 ) N:       0 (+ 0) (P:  0.80%) (Q:  0.05473) (U: 0.24874) (Q+U:  0.30347) (V:  -.----)  C:00000000
info string g4g5  (861 ) N:       0 (+ 0) (P:  1.42%) (Q:  0.05473) (U: 0.43908) (Q+U:  0.49381) (V:  -.----)  C:00000000
info string g4e6  (863 ) N:       0 (+ 0) (P:  1.53%) (Q:  0.05473) (U: 0.47443) (Q+U:  0.52916) (V:  -.----)  C:00000000
info string g4h5  (862 ) N:       0 (+ 0) (P:  2.19%) (Q:  0.05473) (U: 0.67978) (Q+U:  0.73451) (V:  -.----)  C:00000000
info string g4h4  (858 ) N:       0 (+ 0) (P:  2.28%) (Q:  0.05473) (U: 0.70626) (Q+U:  0.76099) (V:  -.----)  C:00000000
info string g2g3  (374 ) N:       0 (+ 0) (P:  2.34%) (Q:  0.05473) (U: 0.72659) (Q+U:  0.78133) (V:  -.----)  C:00000000
info string g1h1  (153 ) N:       0 (+ 0) (P:  2.39%) (Q:  0.05473) (U: 0.74007) (Q+U:  0.79480) (V:  -.----)  C:00000000
info string g4d4  (855 ) N:       0 (+ 0) (P:  2.46%) (Q:  0.05473) (U: 0.76135) (Q+U:  0.81608) (V:  -.----)  C:00000000
info string g4h3  (851 ) N:       0 (+ 0) (P:  2.53%) (Q:  0.05473) (U: 0.78547) (Q+U:  0.84020) (V:  -.----)  C:00000000
info string g4g3  (850 ) N:       0 (+ 0) (P:  2.60%) (Q:  0.05473) (U: 0.80651) (Q+U:  0.86124) (V:  -.----)  C:00000000
info string g4e4  (856 ) N:       0 (+ 0) (P:  2.61%) (Q:  0.05473) (U: 0.80793) (Q+U:  0.86266) (V:  -.----)  C:00000000
info string g4f5  (860 ) N:       0 (+ 0) (P:  2.63%) (Q:  0.05473) (U: 0.81408) (Q+U:  0.86881) (V:  -.----)  C:00000000
info string g4f4  (857 ) N:       0 (+ 0) (P:  2.80%) (Q:  0.05473) (U: 0.86917) (Q+U:  0.92390) (V:  -.----)  C:00000000
info string g4f3  (849 ) N:       0 (+ 0) (P:  2.97%) (Q:  0.05473) (U: 0.92024) (Q+U:  0.97497) (V:  -.----)  C:00000000
info string f2f3  (346 ) N:       0 (+ 0) (P:  2.97%) (Q:  0.05473) (U: 0.92142) (Q+U:  0.97616) (V:  -.----)  C:00000000
info string g4d1  (842 ) N:       0 (+ 0) (P:  3.02%) (Q:  0.05473) (U: 0.93514) (Q+U:  0.98987) (V:  -.----)  C:00000000
info string f2f4  (351 ) N:       1 (+12) (P:  4.45%) (Q:  0.98178) (U: 0.09846) (Q+U:  1.08024) (V:  0.9818)  C:00000000
info string g4c4  (854 ) N:       1 (+ 8) (P:  3.05%) (Q:  0.98656) (U: 0.09455) (Q+U:  1.08111) (V:  0.9866)  C:00000000
info string h2h4  (403 ) N:       1 (+18) (P:  6.07%) (Q:  0.98828) (U: 0.09406) (Q+U:  1.08234) (V:  0.9883)  C:00000000
info string h2h3  (400 ) N:       1 (+ 8) (P:  3.09%) (Q:  0.98668) (U: 0.09578) (Q+U:  1.08246) (V:  0.9867)  C:00000000
info string g4b4  (853 ) N:       1 (+ 8) (P:  3.13%) (Q:  0.98744) (U: 0.09704) (Q+U:  1.08448) (V:  0.9874)  C:00000000
info string g1f1  (152 ) N:       1 (+ 9) (P:  3.64%) (Q:  0.98265) (U: 0.10253) (Q+U:  1.08518) (V:  0.9827)  C:00000000
info string g4e2  (844 ) N:       1 (+ 8) (P:  3.18%) (Q:  0.98716) (U: 0.09846) (Q+U:  1.08562) (V:  0.9872)  C:00000000
info string g4d7  (867 ) N:       1 (+ 8) (P:  3.15%) (Q:  0.98864) (U: 0.09760) (Q+U:  1.08624) (V:  0.9886)  C:00000000
info string g4a4  (852 ) N:       1 (+13) (P:  4.63%) (Q:  0.99068) (U: 0.09571) (Q+U:  1.08639) (V:  0.9907)  C:00000000
info string g4c8  (869 ) N:      97 (+ 0) (P: 27.48%) (Q:  1.00000) (U: 0.08690) (Q+U:  1.08690) (V:  1.0000)  C:01001111
bestmove g4c8

```